### PR TITLE
Added ability to parse numbers formatted with ', press '

### DIFF
--- a/phone_field/forms.py
+++ b/phone_field/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .phone_number import PhoneNumber
+from .phone_number import PhoneNumber, BACKEND_EXTENSION_SEPARATOR
 
 
 class PhoneWidget(forms.MultiWidget):
@@ -20,7 +20,7 @@ class PhoneWidget(forms.MultiWidget):
     def decompress(self, value):
         if not isinstance(value, PhoneNumber):
             value = PhoneNumber(value)
-        return value.base_number_fmt, 'x'.join(value.extensions)
+        return value.base_number_fmt, BACKEND_EXTENSION_SEPARATOR.join(value.extensions)
 
     def get_context(self, name, value, attrs):
         # First sub-widget doesn't get marked as required for some reason
@@ -50,7 +50,7 @@ class PhoneFormField(forms.MultiValueField):
         if not data_list:
             return PhoneNumber('')
 
-        str_val = 'x'.join(x for x in data_list if x)
+        str_val = BACKEND_EXTENSION_SEPARATOR.join(x for x in data_list if x)
         return PhoneNumber(str_val)
 
     def validate(self, value):

--- a/phone_field/phone_number.py
+++ b/phone_field/phone_number.py
@@ -8,6 +8,7 @@ PHONE_TEST_REGEX = re.compile(r'^\+?1?-?\s*'        # optional leading '+1-' and
                               r'[-\.\s]*'           # strip -, ., and whitespace
                               r'(\d{4})$')          # last four digits
 
+BACKEND_EXTENSION_SEPARATOR = 'x'
 VALID_EXTENSION_SEPARATOR = ', press '
 
 class PhoneNumber(object):
@@ -27,7 +28,7 @@ class PhoneNumber(object):
             if VALID_EXTENSION_SEPARATOR in self.raw_phone:
                 parts = self.raw_phone.split(VALID_EXTENSION_SEPARATOR)
             else:
-                parts = self.raw_phone.split('x')
+                parts = self.raw_phone.split(BACKEND_EXTENSION_SEPARATOR)
 
             self._base_number = self._base_number_dirty = parts[0].strip()
             self._extensions = [x.strip() for x in parts[1:]]
@@ -50,7 +51,7 @@ class PhoneNumber(object):
                     self._valid_extensions = False
                     break
             if self._extensions:
-                self._cleaned += 'x' + 'x'.join(self._extensions)
+                self._cleaned += BACKEND_EXTENSION_SEPARATOR + BACKEND_EXTENSION_SEPARATOR.join(self._extensions)
             self._is_parsed = True
 
     @property
@@ -105,7 +106,7 @@ class PhoneNumber(object):
             for ext in self._extensions:
                 val += VALID_EXTENSION_SEPARATOR + str(ext)
         elif self._has_extensions:
-            val += 'x' + 'x'.join(self._extensions)
+            val += BACKEND_EXTENSION_SEPARATOR + BACKEND_EXTENSION_SEPARATOR.join(self._extensions)
         return val
 
     def __str__(self):

--- a/phone_field/phone_number.py
+++ b/phone_field/phone_number.py
@@ -8,6 +8,7 @@ PHONE_TEST_REGEX = re.compile(r'^\+?1?-?\s*'        # optional leading '+1-' and
                               r'[-\.\s]*'           # strip -, ., and whitespace
                               r'(\d{4})$')          # last four digits
 
+VALID_EXTENSION_SEPARATOR = ', press '
 
 class PhoneNumber(object):
     def __init__(self, txt):
@@ -23,7 +24,11 @@ class PhoneNumber(object):
 
     def parse(self):
         if not self._is_parsed and self.raw_phone:
-            parts = self.raw_phone.split('x')
+            if VALID_EXTENSION_SEPARATOR in self.raw_phone:
+                parts = self.raw_phone.split(VALID_EXTENSION_SEPARATOR)
+            else:
+                parts = self.raw_phone.split('x')
+
             self._base_number = self._base_number_dirty = parts[0].strip()
             self._extensions = [x.strip() for x in parts[1:]]
 
@@ -98,7 +103,7 @@ class PhoneNumber(object):
         val = self.base_number_fmt
         if self._valid_extensions:
             for ext in self._extensions:
-                val += ', press {}'.format(ext)
+                val += VALID_EXTENSION_SEPARATOR + str(ext)
         elif self._has_extensions:
             val += 'x' + 'x'.join(self._extensions)
         return val

--- a/test_proj/test_app/tests.py
+++ b/test_proj/test_app/tests.py
@@ -26,6 +26,14 @@ PARSING_TESTS = [
         }
     ),
     (
+        '(415) 123-4567, press 44',
+        'already formatted with valid extensions',
+        {
+            'cleaned': '+14151234567x44', 'formatted': '(415) 123-4567, press 44', 'base_number': '+14151234567',
+            'base_number_fmt': '(415) 123-4567', 'is_E164': False, 'is_standard': True, 'is_usa': True
+        }
+    ),
+    (
         ' (415).123 - 4567 ',
         'messy formatted',
         {


### PR DESCRIPTION
I ran into a corner case where I needed to create a `PhoneNumber` object using the output of another `PhoneNumber` with the "{base_number}, press {extension}" format. This PR makes that possible